### PR TITLE
Fixed verification bug; Flag now required to run prod, dev by default

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: python bot.py
+worker: python bot.py -p

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -50,6 +50,7 @@ class EmailSubmitModal(Modal, title='Enter your Email Address'):
         super().__init__(timeout=None, custom_id="verification:email_modal")
 
     async def on_submit(self, interaction: discord.Interaction):
+        await interaction.response.defer()
         try:
             # Check that the email address is valid.
             validation = validate_email(self.email.value, check_deliverability=True)
@@ -68,7 +69,7 @@ class EmailSubmitModal(Modal, title='Enter your Email Address'):
                     description="Not match found associated with that email address. Please make sure to use the same email address you used to apply.", 
                     color=discord.Color.red(),
                 )
-                await interaction.response.send_message(embed=embed_response, ephemeral=True)
+                await interaction.followup.send(embed=embed_response, ephemeral=True)
 
             elif "Discord ID" in user_record['fields']:
                 title = '<a:utilsuccess:809713352061354016> Already Verified!'
@@ -85,7 +86,7 @@ class EmailSubmitModal(Modal, title='Enter your Email Address'):
                     color=color,
                 )
                 embed_response.set_footer(text="If you still don't get access, please reach out to a mod for assistance.")
-                response = await interaction.response.send_message(embed=embed_response, ephemeral=True)
+                response = await interaction.followup.send(embed=embed_response, ephemeral=True)
             else:
                 # Send email with generated verification_token
                 verification_token = send_verification_SMTP_email(validated_email)
@@ -99,14 +100,14 @@ class EmailSubmitModal(Modal, title='Enter your Email Address'):
                         color=YELLOW_COLOR,
                     )
                     button = VerifyControls(user_record, verification_token)
-                    await interaction.response.send_message(embed=embed_response, view=button, ephemeral=True)
+                    await interaction.followup.send(embed=embed_response, view=button, ephemeral=True)
                 else:
                     embed_response = discord.Embed(
                         title="<a:utilfailure:809713365088993291> Something unexpected happened...", 
                         description="Please try again. The developers have been notified of this.", 
                         color=discord.Color.red(),
                     )
-                    await interaction.response.send_message(embed=embed_response, view=button, ephemeral=True)
+                    await interaction.followup.send(embed=embed_response, view=button, ephemeral=True)
                 
         except EmailNotValidError as e:
             # Email is not valid.
@@ -115,7 +116,7 @@ class EmailSubmitModal(Modal, title='Enter your Email Address'):
                 description="Please make sure you spelled it correctly.", 
                 color=discord.Color.red()
             )
-            await interaction.response.send_message(embed=embed_response, ephemeral=True)
+            await interaction.followup.send(embed=embed_response, ephemeral=True)
 
 class VerificationCodeSubmitModal(Modal, title='Enter Verification Code'):
     token_input = TextInput(

--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 import argparse
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-d", "--isDev", help="Development Mode", action='store_true')
+parser.add_argument("-p", "--isProd", help="Production Mode", action='store_true')
 args = parser.parse_args()
 
-isProd = not args.isDev
+isProd = args.isProd


### PR DESCRIPTION
- Response is now deferred while we fetch Airtable data and then we send a follow up. This prevents Discord from timing out the interaction returning 404 when the action takes more than 5 seconds. 
- Adding `-d` flag every time was getting annoying so default is now dev and prod uses `-p` flag which the Heroku proc file includes.