### PR TITLE
Update /roles spread to handle new usernames

### DIFF
--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -33,6 +33,11 @@ class Roles(commands.GroupCog, name="roles"):
         self.GREEN_HEX = 0x238823
         self.YELLOW_HEX = 0xFFBF00
         self.RED_HEX = 0xD2222D
+    
+    @commands.Cog.listener()
+    async def on_ready(self):
+        for guild in self.bot.guilds:
+            await guild.fetch_members().flatten()
 
     @app_commands.command(name="see",
                           description="Used to inquire about a role.")

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -363,11 +363,12 @@ class Roles(commands.GroupCog, name="roles"):
                         member = await interaction.guild.fetch_member(int(member_name_parts[0].strip()))
                     else:  # assume it's a username
                         if len(member_name_parts) <= 1:
-                            raise commands.BadArgument
-                        member = discord.utils.get(
-                            interaction.guild.members,
-                            name=member_name_parts[0].strip(),
-                            discriminator=member_name_parts[1].strip())
+                            member = interaction.guild.get_member_named(member_name)
+                        else:
+                            member = discord.utils.get(
+                                interaction.guild.members,
+                                name=member_name_parts[0].strip(),
+                                discriminator=member_name_parts[1].strip())
                 except (commands.BadArgument, commands.MemberNotFound, discord.errors.NotFound) as error:
                     failed_users.append(member_name)
                 else:


### PR DESCRIPTION
Discord has since retired the discriminator and `/roles spread` currently only allows supplying names following `[0-9]+` (discord ID) or `[a-zA-Z0-9._]{2,32}#[0-9]{4}` (username then discriminator), but now it can deal with new usernames, as well.

# IMPORTANT
This code is untested as I've been unable to install dependencies without errors happening, so exercise caution when looking this over.