### PR TITLE
installed pytorch using cpu only (no CUDA cores)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ google-cloud-storage==2.7.0
 google-crc32c==1.5.0
 google-resumable-media==2.4.1
 googleapis-common-protos==1.59.0
-grpcio==1.51.3
+grpcio==1.75.0
 grpcio-status==1.51.3
 h11==0.16.0
 hf-xet==1.1.10
@@ -57,7 +57,6 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pyparsing==3.0.9
 python-dotenv==0.15.0
-python-Levenshtein==0.21.1
 PyYAML==6.0.2
 RapidFuzz==3.14.0
 regex==2025.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ filelock==3.19.1
 firebase-admin==5.3.0
 frozenlist==1.7.0
 fsspec==2025.9.0
+fuzzywuzzy==0.18.0
 google-api-core==2.11.0
 google-api-python-client==2.82.0
 google-auth==2.16.2
@@ -27,7 +28,7 @@ google-cloud-storage==2.7.0
 google-crc32c==1.5.0
 google-resumable-media==2.4.1
 googleapis-common-protos==1.59.0
-grpcio==1.75.0
+grpcio==1.51.3
 grpcio-status==1.51.3
 h11==0.16.0
 hf-xet==1.1.10
@@ -41,7 +42,7 @@ joblib==1.5.2
 MarkupSafe==3.0.2
 mpmath==1.3.0
 msgpack==1.0.5
-multidict==5.1.0
+multidict==6.6.4
 networkx==3.5
 notion-client==2.2.1
 numpy==2.3.3
@@ -56,9 +57,10 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pyparsing==3.0.9
 python-dotenv==0.15.0
+python-Levenshtein==0.21.1
 PyYAML==6.0.2
-RapidFuzz==3.14.1
-regex==2025.9.18
+RapidFuzz==3.14.0
+regex==2025.9.1
 requests==2.28.2
 requests-oauthlib==1.3.1
 rsa==4.9
@@ -70,10 +72,12 @@ six==1.16.0
 sniffio==1.3.1
 sympy==1.14.0
 threadpoolctl==3.6.0
-tokenizers==0.22.1
+tokenizers==0.22.0
 torch==2.8.0
+torchaudio==2.8.0
+torchvision==0.23.0
 tqdm==4.67.1
-transformers==4.56.2
+transformers==4.56.1
 typing_extensions==4.15.0
 uritemplate==4.1.1
 urllib3==1.26.15


### PR DESCRIPTION
```
(venv) (base) dabian@MacBookAir Makernaut %   pip install torch torchvision torchaudio  \        
    --index-url https://download.pytorch.org/whl/cpu
Looking in indexes: https://download.pytorch.org/whl/cpu
Collecting torch
  Obtaining dependency information for torch from https://download.pytorch.org/whl/cpu/torch-2.8.0-cp311-none-macosx_11_0_arm64.whl.metadata
  Using cached https://download.pytorch.org/whl/cpu/torch-2.8.0-cp311-none-macosx_11_0_arm64.whl.metadata (29 kB)
Collecting torchvision
  Obtaining dependency information for torchvision from https://download.pytorch.org/whl/cpu/torchvision-0.23.0-cp311-cp311-macosx_11_0_arm64.whl.metadata
  Using cached https://download.pytorch.org/whl/cpu/torchvision-0.23.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (6.1 kB)
Collecting torchaudio
  Obtaining dependency information for torchaudio from https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp311-cp311-macosx_11_0_arm64.whl.metadata
  Using cached https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (7.2 kB)
Requirement already satisfied: filelock in ./venv/lib/python3.11/site-packages (from torch) (3.19.1)
Requirement already satisfied: typing-extensions>=4.10.0 in ./venv/lib/python3.11/site-packages (from torch) (4.15.0)
Requirement already satisfied: sympy>=1.13.3 in ./venv/lib/python3.11/site-packages (from torch) (1.14.0)
Requirement already satisfied: networkx in ./venv/lib/python3.11/site-packages (from torch) (3.5)
Requirement already satisfied: jinja2 in ./venv/lib/python3.11/site-packages (from torch) (3.1.6)
Requirement already satisfied: fsspec in ./venv/lib/python3.11/site-packages (from torch) (2025.9.0)
Requirement already satisfied: numpy in ./venv/lib/python3.11/site-packages (from torchvision) (2.3.3)
Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in ./venv/lib/python3.11/site-packages (from torchvision) (11.3.0)
Requirement already satisfied: mpmath<1.4,>=1.1.0 in ./venv/lib/python3.11/site-packages (from sympy>=1.13.3->torch) (1.3.0)
Requirement already satisfied: MarkupSafe>=2.0 in ./venv/lib/python3.11/site-packages (from jinja2->torch) (3.0.2)
Using cached https://download.pytorch.org/whl/cpu/torch-2.8.0-cp311-none-macosx_11_0_arm64.whl (73.5 MB)
Using cached https://download.pytorch.org/whl/cpu/torchvision-0.23.0-cp311-cp311-macosx_11_0_arm64.whl (1.9 MB)
Using cached https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp311-cp311-macosx_11_0_arm64.whl (1.9 MB)
Using cached https://download.pytorch.org/whl/cpu/torch-2.8.0-cp311-none-macosx_11_0_arm64.whl (73.5 MB)
Using cached https://download.pytorch.org/whl/cpu/torchvision-0.23.0-cp311-cp311-macosx_11_0_arm64.whl (1.9 MB)
Using cached https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp311-cp311-macosx_11_0_arm64.whl (1.9 MB)
Installing collected packages: torch, torchvision, torchaudio
Successfully installed torch-2.8.0 torchaudio-2.8.0 torchvision-0.23.0

[notice] A new release of pip is available: 23.1.2 -> 25.2
[notice] To update, run: pip install --upgrade pip
```
--- 
```
(venv) (base) dabian@MacBookAir Makernaut % pip freeze | grep -E 'torch|torchvision|torchaudio'

torch==2.8.0
torchaudio==2.8.0
torchvision==0.23.0
```
---
```
(venv) (base) dabian@MacBookAir Makernaut % python -c "import torch; print(torch.version.cuda)"

None
```